### PR TITLE
카카오 인가 코드 처리 및 디비 유저 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    //Webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/footlogger/footlog/domain/User.java
+++ b/src/main/java/footlogger/footlog/domain/User.java
@@ -39,4 +39,6 @@ public class User {
 
     @Setter
     private String refreshToken;
+    @Setter
+    private String accessToken;
 }

--- a/src/main/java/footlogger/footlog/service/KakaoService.java
+++ b/src/main/java/footlogger/footlog/service/KakaoService.java
@@ -1,112 +1,71 @@
 package footlogger.footlog.service;
 
+import ch.qos.logback.core.joran.util.beans.BeanDescriptionFactory;
 import footlogger.footlog.domain.User;
 import footlogger.footlog.domain.jwt.JWTUtil;
+import footlogger.footlog.web.dto.response.KakaoTokenResponseDto;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
 import java.util.Map;
 import java.util.Optional;
 
+@Slf4j
 @Service
-@RequiredArgsConstructor
+
 public class KakaoService {
 
-    @Value("${kakao.client-id}")
-    private String clientId;
+    private final String clientId;
+    private final String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com";
+    private final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
 
-    @Value("${kakao.redirect-uri}")
-    private String redirectUri;
-
-    @Value("${kakao.token-uri}")
-    private String tokenUri;
-
-    @Value("${kakao.user-info-uri}")
-    private String userInfoUri;
-
-    private final RestTemplate restTemplate;
-    private final UserService userService;
-    private final JWTUtil jwtUtil;
-
-    public String getAccessToken(String code) {
-        // 카카오 서버로부터 액세스 토큰을 요청하는 메서드
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(tokenUri)
-                .queryParam("grant_type", "authorization_code")
-                .queryParam("client_id", clientId)
-                .queryParam("redirect_uri", redirectUri)
-                .queryParam("code", code);
-
-        HttpEntity<?> request = new HttpEntity<>(headers);
-        ResponseEntity<Map> response = restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.POST, request, Map.class);
-
-        if(response.getStatusCode() == HttpStatus.OK) {
-            Map<String, Object> responseBody = response.getBody();
-            return (String) responseBody.get("access_token");
-        }
-
-        throw new RuntimeException("Failed to get access token from Kakao");
-
+    @Autowired
+    public KakaoService(@Value("${kakao.client_id}") String clientId) {
+        this.clientId = clientId;
     }
 
-    public Map<String, Object> getUserInfo(String accessToken) {
-        // 액세스 토큰으로 사용자 정보를 요청하는 메서드
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(accessToken);
-        HttpEntity<?> request = new HttpEntity<>(headers);
+    public String getAccessTokenFromKakao(String code) {
+        try {
+            KakaoTokenResponseDto kakaoTokenResponseDto = WebClient.create(KAUTH_TOKEN_URL_HOST).post()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/oauth/token")
+                            .queryParam("grant_type", "authorization_code")
+                            .queryParam("client_id", clientId)
+                            .queryParam("redirect_uri", "http://localhost:3000/user/kakao/callback")
+                            .queryParam("code", code)
+                            .build())
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
+                        log.error("4xx error when requesting access token: {}", clientResponse.statusCode());
+                        return Mono.error(new RuntimeException("Invalid Parameter - " + clientResponse.statusCode()));
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> {
+                        log.error("5xx error when requesting access token: {}", clientResponse.statusCode());
+                        return Mono.error(new RuntimeException("Internal Server Error - " + clientResponse.statusCode()));
+                    })
+                    .bodyToMono(KakaoTokenResponseDto.class)
+                    .block();
 
-        ResponseEntity<Map> response = restTemplate.exchange(userInfoUri, HttpMethod.GET, request, Map.class);
+            log.info(" [Kakao Service] Access Token ------> {}", kakaoTokenResponseDto.getAccessToken());
+            log.info(" [Kakao Service] Refresh Token ------> {}", kakaoTokenResponseDto.getRefreshToken());
+            log.info(" [Kakao Service] Id Token ------> {}", kakaoTokenResponseDto.getIdToken());
+            log.info(" [Kakao Service] Scope ------> {}", kakaoTokenResponseDto.getScope());
 
-        if(response.getStatusCode() == HttpStatus.OK) {
-            return response.getBody();
+            return kakaoTokenResponseDto.getAccessToken();
+        } catch (Exception e) {
+            log.error("Error occurred while getting access token from Kakao: ", e);
+            throw new RuntimeException("Failed to retrieve access token from Kakao", e);
         }
-
-        throw new RuntimeException("Failed to get user info from Kakao");
-
     }
-
-    public User processKakaoLogin(String code) {
-        // 카카오 로그인 처리 메서드
-        String accessToken = getAccessToken(code);
-        Map<String, Object> userInfo = getUserInfo(accessToken);
-
-        // 카카오에서 받아온 사용자 정보 추출
-        String email = (String) ((Map<String, Object>) userInfo.get("kakao_account")).get("email");
-        Long kakaoId = ((Number) userInfo.get("id")).longValue();
-        String nickname = (String) ((Map<String, Object>) userInfo.get("properties")).get("nickname");
-        String profileImg = (String) ((Map<String, Object>) userInfo.get("properties")).get("profile_image");
-
-        // DB에서 사용자 정보를 확인
-        Optional<User> optionalUser = userService.findByKakaoId(kakaoId);
-        User user;
-
-        if(optionalUser.isPresent()) {
-            // 사용자가 존재하면 그 사용자 정보를 가져옴
-            user = optionalUser.get();
-
-        }
-         else {
-            // 사용자가 없으면 회원가입 처리
-             user = User.builder()
-                     .kakaoId(kakaoId)
-                     .email(email)
-                     .nickname(nickname)
-                     .profileImg(profileImg)
-                     .build();
-        }
-
-         String accessTokenJwt = jwtUtil.createAccessToken(email);
-         String refreshTokenJwt = jwtUtil.createRefreshToken(email);
-
-        user.setRefreshToken(refreshTokenJwt);
-         userService.save(user);
-
-         return user;
-    }
-
 }
+

--- a/src/main/java/footlogger/footlog/web/controller/UserController.java
+++ b/src/main/java/footlogger/footlog/web/controller/UserController.java
@@ -3,6 +3,7 @@ package footlogger.footlog.web.controller;
 import footlogger.footlog.domain.User;
 import footlogger.footlog.service.KakaoService;
 import footlogger.footlog.service.UserService;
+import footlogger.footlog.web.dto.response.KakaoUserInfoResponseDto;
 import footlogger.footlog.web.dto.response.UserResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +25,7 @@ public class UserController {
     public ResponseEntity<?> callback(@RequestParam("code") String code) throws IOException {
         try {
             String accessToken = kakaoService.getAccessTokenFromKakao(code);
+            KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(accessToken);
             return new ResponseEntity<>(accessToken, HttpStatus.OK);
         } catch (Exception e) {
             log.error("Error during Kakao callback: ", e);

--- a/src/main/java/footlogger/footlog/web/controller/UserController.java
+++ b/src/main/java/footlogger/footlog/web/controller/UserController.java
@@ -1,8 +1,10 @@
 package footlogger.footlog.web.controller;
 
 import footlogger.footlog.domain.User;
+import footlogger.footlog.payload.ApiResponse;
 import footlogger.footlog.service.KakaoService;
 import footlogger.footlog.service.UserService;
+import footlogger.footlog.web.dto.response.KakaoTokenResponseDto;
 import footlogger.footlog.web.dto.response.KakaoUserInfoResponseDto;
 import footlogger.footlog.web.dto.response.UserResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.util.Map;
+
+import static footlogger.footlog.payload.code.status.ErrorStatus._INTERNAL_SERVER_ERROR;
 
 @Slf4j
 @RestController
@@ -22,14 +27,19 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/kakao/callback")
-    public ResponseEntity<?> callback(@RequestParam("code") String code) throws IOException {
+    public ResponseEntity<?> callback(@RequestParam("code") String code) {
         try {
-            String accessToken = kakaoService.getAccessTokenFromKakao(code);
-            KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(accessToken);
-            return new ResponseEntity<>(accessToken, HttpStatus.OK);
+            KakaoTokenResponseDto kakaoTokenResponseDto = kakaoService.getAccessTokenFromKakao(code);
+            KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(kakaoTokenResponseDto.getAccessToken());
+            kakaoService.handleUserRegistration(userInfo, kakaoTokenResponseDto);
+
+            return new ResponseEntity<>(ApiResponse.onSuccess(Map.of(
+                    "accessToken", kakaoTokenResponseDto.getAccessToken(),
+                    "refreshToken", kakaoTokenResponseDto.getAccessToken()
+            )), HttpStatus.OK);
         } catch (Exception e) {
             log.error("Error during Kakao callback: ", e);
-            return new ResponseEntity<>("Failed to process Kakao callback", HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(ApiResponse.onFailure(_INTERNAL_SERVER_ERROR, null), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/footlogger/footlog/web/controller/UserController.java
+++ b/src/main/java/footlogger/footlog/web/controller/UserController.java
@@ -5,8 +5,14 @@ import footlogger.footlog.service.KakaoService;
 import footlogger.footlog.service.UserService;
 import footlogger.footlog.web.dto.response.UserResponseDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
@@ -15,9 +21,14 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/kakao/callback")
-    public UserResponseDto.LoginResultDto kakaoCallBack(@RequestParam String code) {
-        User user = kakaoService.processKakaoLogin(code);
-        return new UserResponseDto.LoginResultDto(user.getId(), user.getNickname(), user.getProfileImg());
+    public ResponseEntity<?> callback(@RequestParam("code") String code) throws IOException {
+        try {
+            String accessToken = kakaoService.getAccessTokenFromKakao(code);
+            return new ResponseEntity<>(accessToken, HttpStatus.OK);
+        } catch (Exception e) {
+            log.error("Error during Kakao callback: ", e);
+            return new ResponseEntity<>("Failed to process Kakao callback", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     @GetMapping("/info")

--- a/src/main/java/footlogger/footlog/web/dto/response/KakaoTokenResponseDto.java
+++ b/src/main/java/footlogger/footlog/web/dto/response/KakaoTokenResponseDto.java
@@ -1,0 +1,26 @@
+package footlogger.footlog.web.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor //역직렬화를 위한 기본 생성자
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponseDto {
+    @JsonProperty("token_type")
+    public String tokenType;
+    @JsonProperty("access_token")
+    public String accessToken;
+    @JsonProperty("id_token")
+    public String idToken;
+    @JsonProperty("expires_in")
+    public Integer expiresIn;
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+    @JsonProperty("refresh_token_expires_in")
+    public Integer refreshTokenExpiresIn;
+    @JsonProperty("scope")
+    public String scope;
+}

--- a/src/main/java/footlogger/footlog/web/dto/response/KakaoUserInfoResponseDto.java
+++ b/src/main/java/footlogger/footlog/web/dto/response/KakaoUserInfoResponseDto.java
@@ -1,0 +1,59 @@
+package footlogger.footlog.web.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.awt.color.ICC_ColorSpace;
+
+@Getter
+@NoArgsConstructor //역직렬화를 위한 기본 생성자
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfoResponseDto {
+    //회원 번호
+    @JsonProperty("id")
+    public Long id;
+    //카카오 계정 정보
+    @JsonProperty("kakao_account")
+    public KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoAccount {
+        //카카오계정 이름
+        @JsonProperty("name")
+        public String name;
+        //카카오계정 대표 이메일
+        @JsonProperty("email")
+        public String email;
+        //사용자 프로필 정보
+        @JsonProperty("profile")
+        public Profile profile;
+
+    }
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Profile {
+        //닉네임
+        @JsonProperty("nickname")
+        public String nickName;
+        //프로필 미리보기 이미지 URL
+        @JsonProperty("thumbnail_image_url")
+        public String thumbnailImageUrl;
+
+        //프로필 사진 URL
+        @JsonProperty("profile_image_url")
+        public String profileImageUrl;
+    }
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Partner {
+        //고유 ID
+        @JsonProperty("uuid")
+        public String uuid;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,5 +35,5 @@ jwt:
 kakao:
   client_id: ${REST_API_KEY}
   redirect_uri: ${REDIRECT_URI}
-  token-uri: "https://kauth.kakao.com/oauth/token" # 토큰 발급 요청 URI
-  user-info-uri: "https://kapi.kakao.com/v2/user/me" # 사용자 정보 요청 URI
+  token_uri: "https://kauth.kakao.com" # 토큰 발급 요청 URI
+  user_info_uri: "https://kapi.kakao.com" # 사용자 정보 요청 URI

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,9 +16,9 @@ spring:
         use_sql_comments: true
         jdbc:
           time_zone: Asia/Seoul
-server:
-  servlet:
-    context-path: /api
+#server:
+#  servlet:
+#    context-path: /api
 
 springdoc:
   swagger-ui:
@@ -33,7 +33,7 @@ jwt:
   refresh-token-validity: 86400000 # 1 week
 
 kakao:
-  client-id: ${REST_API_KEY}
-  redirect-uri: ${REDIRECT_URI}
+  client_id: ${REST_API_KEY}
+  redirect_uri: ${REDIRECT_URI}
   token-uri: "https://kauth.kakao.com/oauth/token" # 토큰 발급 요청 URI
   user-info-uri: "https://kapi.kakao.com/v2/user/me" # 사용자 정보 요청 URI


### PR DESCRIPTION
## 연관 이슈

#3

<br/>

## 개요

카카오 인가 코드 처리 및 디비 유저 저장

<br/>

## ✅ 작업 내용

- [x] 카카오 인가 코드 처리 
KakaoService 코드 보면 `getAccessTokenFromKakao` 함수가 프론트에서 받은 code로 엑세스 코드 발급 받는 부분이야.
`getUserInfo` 함수에서는 이 코드를 이용해서 카카오에 유저 정보 요청하는 부분!
- [x] 디비 유저 저장
마지막으로 `handleUserRegistration` 함수로 디비에 유저 정보 저장했어.

근데 코드는 좀 더 수정될 것 같아...

<br/>

### 📝 논의사항

헤더 엑세스 토큰으로 유저 정보 확인 코드 구현
