### PR TITLE
[Feat] s3 이미지 업로드 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     //Webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/footlogger/footlog/service/S3ImageService.java
+++ b/src/main/java/footlogger/footlog/service/S3ImageService.java
@@ -1,0 +1,127 @@
+package footlogger.footlog.service;
+
+import ch.qos.logback.core.status.ErrorStatus;
+import com.amazonaws.internal.http.ErrorCodeParser;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.*;
+import com.amazonaws.util.IOUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.ion.IonException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Component
+public class S3ImageService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String upload(MultipartFile image) {
+        //입력받은 이미지 파일이 비었는지 검증
+        if(image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
+            throw new IllegalArgumentException("image is empty");
+        }
+        //uploadImage를 호출하여 S3에 저장된 이미지의 public url 반환
+        return this.uploadImage(image);
+    }
+
+    private String uploadImage(MultipartFile image) {
+        //확장자 명이 올바른지 확인
+        this.validateImageFileExtention(image.getOriginalFilename());
+        //이미지 업로드
+        try {
+            return this.uploadImageToS3(image);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("이미지 업로드 실패");
+        }
+    }
+
+    //파일 확장자 검사
+    private void validateImageFileExtention(String filename) {
+        int lastDotIndex = filename.lastIndexOf('.');
+        if(lastDotIndex == -1) {
+            throw new IllegalArgumentException("파일 확장자 없음");
+        }
+
+        String extension = filename.substring(lastDotIndex + 1).toLowerCase();
+        List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+        if(!allowedExtentionList.contains(extension)) {
+            throw new IllegalArgumentException("올바른 확장자 아님");
+        }
+    }
+
+    private String uploadImageToS3(MultipartFile image) throws IOException {
+        //원본 파일명
+        String originalFilename = image.getOriginalFilename();
+        //확장자 명
+        String extension = originalFilename.substring(originalFilename.lastIndexOf('.'));
+        //변경된 파일명
+        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename;
+
+        //image를 byte[]로 변환
+        InputStream is = image.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(is);
+
+        //metadata 생성
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/" + extension);
+        metadata.setContentLength(bytes.length);
+
+        //S3에 요청할 때 사용할 byteInputStream 생성
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+        try{
+            //S3로 putObject 할 때 사용할 요청 객체
+            //생성자 : bucket 이름, 파일 명, byteInputStream, metadata
+            PutObjectRequest putObjectRequest =
+                    new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead);
+
+            //실제로 S3에 이미지 데이터를 넣는 부분
+            amazonS3.putObject(putObjectRequest);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("데이터 오류");
+        } finally {
+            byteArrayInputStream.close();
+            is.close();
+        }
+        return amazonS3.getUrl(bucketName, s3FileName).toString();
+    }
+
+    private void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);
+
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("이미지 삭제 실패");
+        }
+    }
+
+    private String getKeyFromImageAddress(String imageAddress) {
+        try {
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1);
+        } catch (MalformedURLException | UnsupportedEncodingException e) {
+            throw new IllegalArgumentException("이미지 삭제 실패");
+        }
+    }
+}

--- a/src/main/java/footlogger/footlog/utils/S3Config.java
+++ b/src/main/java/footlogger/footlog/utils/S3Config.java
@@ -1,0 +1,34 @@
+package footlogger.footlog.utils;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/footlogger/footlog/web/controller/CourseController.java
+++ b/src/main/java/footlogger/footlog/web/controller/CourseController.java
@@ -3,16 +3,17 @@ package footlogger.footlog.web.controller;
 import footlogger.footlog.domain.Course;
 import footlogger.footlog.payload.ApiResponse;
 import footlogger.footlog.service.CourseService;
+import footlogger.footlog.service.S3ImageService;
 import footlogger.footlog.service.SaveService;
 import footlogger.footlog.web.dto.response.CourseDetailDTO;
 import footlogger.footlog.web.dto.response.CourseResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -22,6 +23,7 @@ import java.util.List;
 public class CourseController {
     private final CourseService courseService;
     private final SaveService saveService;
+    private final S3ImageService s3ImageService;
 
     @Operation(summary = "지역 선택 시 해당 코스 반환")
     @GetMapping("/area/{area_name}")
@@ -56,5 +58,14 @@ public class CourseController {
         courseService.toggleSaveCourse(course_id, user_id);
 
         return ApiResponse.onSuccess(saveService.getSaveStatus(course_id, user_id));
+    }
+
+
+    @Operation( summary = "이미지 업로드 테스트")
+    @PostMapping(value = "/s3/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> s3Upload(@RequestParam(value = "image") MultipartFile image) {
+        String profileImage = s3ImageService.upload(image);
+
+        return ResponseEntity.ok(profileImage);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,13 @@ spring:
         use_sql_comments: true
         jdbc:
           time_zone: Asia/Seoul
+
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
+      resolve-lazily: true
+      enabled: true
 #server:
 #  servlet:
 #    context-path: /api
@@ -27,13 +34,24 @@ springdoc:
     tags-sorter: alpha
     operations-sorter: method
 
+cloud:
+  aws:
+    credentials:
+      access-key: ${aws_access}
+      secret-key: ${aws_secret}
+    region:
+      static: ap-northeast-2
+      # 리전 서울로 설정
+    s3:
+      bucket: footlog-bucket
+
 jwt:
   secret: ${secret_key}
   access-token-validity: 7200000 # 2 hour
   refresh-token-validity: 86400000 # 1 week
 
-kakao:
-  client_id: ${REST_API_KEY}
-  redirect_uri: ${REDIRECT_URI}
-  token_uri: "https://kauth.kakao.com" # 토큰 발급 요청 URI
-  user_info_uri: "https://kapi.kakao.com" # 사용자 정보 요청 URI
+#kakao:
+#  client_id: ${REST_API_KEY}
+#  redirect_uri: ${REDIRECT_URI}
+#  token_uri: "https://kauth.kakao.com" # 토큰 발급 요청 URI
+#  user_info_uri: "https://kapi.kakao.com" # 사용자 정보 요청 URI


### PR DESCRIPTION
## 연관 이슈

close #28

<br/>

## 개요

s3 이미지 업로드 기능 추가

<br/>

## ✅ 작업 내용

- [x] s3 이미지 업로드 기능 추가

<br/>

### 📝 논의사항

1. yml파일 카카오 부분 주석 처리 되었음 이거 내 로컬에서는 바꾸기가 복잡해서 그냥 사용할때 주석 해제하고 나중에 다시 머지하는게 좋을듯

2. 이미지 업로드 하는 방법 예시는 CourseController 마지막에 기능만들어두었으니 참고
그냥 s3ImageService의 upload기능 사용하면 됨

<img width="1134" alt="image" src="https://github.com/user-attachments/assets/5de519ea-1471-48a6-9ae5-9f02cdd1d37a">

성공하면 이렇게 url 날라옴
