### PR TITLE
[Feat] 검색 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.json:json:20230618'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	//Jackson
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.72.Final'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/footlogger/footlog/config/RedisConfig.java
+++ b/src/main/java/footlogger/footlog/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package footlogger.footlog.config;
+
+import footlogger.footlog.domain.SearchLog;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.data.redis.RedisConnectionDetails;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, SearchLog> SearchLogRedis() {
+        RedisTemplate<String, SearchLog> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(SearchLog.class));
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(SearchLog.class));
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/footlogger/footlog/converter/SearchLogConverter.java
+++ b/src/main/java/footlogger/footlog/converter/SearchLogConverter.java
@@ -1,0 +1,16 @@
+package footlogger.footlog.converter;
+
+import footlogger.footlog.domain.SearchLog;
+import footlogger.footlog.web.dto.response.SearchLogDTO;
+
+import java.util.List;
+
+public class SearchLogConverter {
+
+    public static SearchLogDTO toDTO(SearchLog searchLog) {
+        return SearchLogDTO.builder()
+                .log(searchLog.getLog())
+                .CreatedAt(searchLog.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/footlogger/footlog/domain/SearchLog.java
+++ b/src/main/java/footlogger/footlog/domain/SearchLog.java
@@ -1,0 +1,15 @@
+package footlogger.footlog.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class SearchLog {
+    private String log;
+    private String createdAt;
+}

--- a/src/main/java/footlogger/footlog/service/SearchService.java
+++ b/src/main/java/footlogger/footlog/service/SearchService.java
@@ -1,0 +1,80 @@
+package footlogger.footlog.service;
+
+import footlogger.footlog.converter.SearchLogConverter;
+import footlogger.footlog.domain.SearchLog;
+import footlogger.footlog.domain.User;
+import footlogger.footlog.repository.UserRepository;
+import footlogger.footlog.web.dto.response.SearchLogDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+    private final UserRepository userRepository;
+    private final RedisTemplate<String, SearchLog> redisTemplate;
+
+    //검색어 저장 기능
+    public void saveRecentSearchLog(String token, String keword) {
+        User user = userRepository.findByAccessToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        String now = LocalDateTime.now().toString();
+
+        //key값 : SearchLog + 유저 id 값
+        String key = "SearchLog" + user.getId();
+        SearchLog value = SearchLog.builder()
+                .log(keword)
+                .createdAt(now)
+                .build();
+
+        Long size = redisTemplate.opsForList().size(key);
+
+        //10개를 넘을 경우 가장 오래된 데이터 삭제
+        if(size == 10) {
+            redisTemplate.opsForList().rightPop(key);
+        }
+
+        redisTemplate.opsForList().leftPush(key, value);
+    }
+
+    //검색 기록 조회
+    public List<SearchLogDTO> getRecentSearchLogs(String token) {
+        User user = userRepository.findByAccessToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        String key = "SearchLog" + user.getId();
+
+        List<SearchLog> logs = redisTemplate.opsForList().range(key, 0, 10);
+
+        return logs.stream()
+                .map(SearchLogConverter::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    public Long deleteRecentSearchLog(String token, SearchLogDTO request) {
+        User user = userRepository.findByAccessToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        String key = "SearchLog" + user.getId();
+        SearchLog value = SearchLog.builder()
+                .log(request.getLog())
+                .createdAt(request.getCreatedAt())
+                .build();
+
+        long count = redisTemplate.opsForList().remove(key, 1, value);
+
+        if(count == 0) {
+            throw new IllegalArgumentException("검색어가 존재하지 않습니다.");
+        }
+
+        return count;
+    }
+}

--- a/src/main/java/footlogger/footlog/web/controller/SearchController.java
+++ b/src/main/java/footlogger/footlog/web/controller/SearchController.java
@@ -1,0 +1,52 @@
+package footlogger.footlog.web.controller;
+
+import footlogger.footlog.payload.ApiResponse;
+import footlogger.footlog.repository.CourseRepository;
+import footlogger.footlog.service.CourseService;
+import footlogger.footlog.service.SearchService;
+import footlogger.footlog.web.dto.response.CourseResponseDTO;
+import footlogger.footlog.web.dto.response.SearchLogDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class SearchController {
+    private final SearchService searchService;
+    private final CourseService courseService;
+    private final CourseRepository courseRepository;
+
+    @Operation(summary = "최근 검색어 조회")
+    @GetMapping("/search/recent")
+    public ApiResponse<List<SearchLogDTO>> findRecentSearchLog(
+            @RequestHeader("Authorization") String token
+    ) {
+        List<SearchLogDTO> recentSearchLogList = searchService.getRecentSearchLogs(token);
+
+        return ApiResponse.onSuccess(recentSearchLogList);
+    }
+
+    @Operation(summary = "검색어 삭제")
+    @PatchMapping("/search/delete")
+    public ApiResponse<Long> deleteSearchLog(
+            @RequestHeader("Authorization") String token,
+            @RequestBody SearchLogDTO requestBody
+    ) {
+        return ApiResponse.onSuccess(searchService.deleteRecentSearchLog(token, requestBody));
+    }
+
+    @Operation(summary = "검색")
+    @GetMapping("/search/course/{keyword}")
+    public ApiResponse<List<CourseResponseDTO>> searchCourse(
+            @RequestHeader("Authorization") String token,
+            @PathVariable("keyword") String keyword
+    ) {
+        searchService.saveRecentSearchLog(token, keyword);
+
+        return ApiResponse.onSuccess(courseService.getByAreaName("서울", 1L));
+    }
+}

--- a/src/main/java/footlogger/footlog/web/dto/response/SearchLogDTO.java
+++ b/src/main/java/footlogger/footlog/web/dto/response/SearchLogDTO.java
@@ -1,0 +1,11 @@
+package footlogger.footlog.web.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SearchLogDTO {
+    private String log;
+    private String CreatedAt;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,11 @@ spring:
 #  servlet:
 #    context-path: /api
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 springdoc:
   swagger-ui:
     path: /swagger
@@ -59,3 +64,4 @@ kakao:
   redirect_uri: ${REDIRECT_URI}
   token_uri: "https://kauth.kakao.com" # 토큰 발급 요청 URI
   user_info_uri: "https://kapi.kakao.com" # 사용자 정보 요청 URI
+


### PR DESCRIPTION
## 연관 이슈

<br/>

## 개요

검색 기록 기능 추가
검색 로직 기능은 추후 추가 예정

<br/>

## ✅ 작업 내용

- [x] 검색 기록 조회 기능
<img width="1119" alt="image" src="https://github.com/user-attachments/assets/07b63c0f-ae43-4b9b-96d7-e0d856023379">

log 는 검색어
createdAt 은 검색한 시간 -> 검색어의 id역할을 함

- [x] 검색 기록 삭제 기능
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/3e80c2f4-b25e-4110-97ae-5ca1dfc83ee0">

반환값으로 남은 검색기록 개수가 나옴
지금은 data: 0 이렇게 나오는데 추후에 저번에 바꿔달라 했던거랑 같이 dto 만들어서 반환 시키겠음 

- [x] 검색 기능
검색 기능은 조금 복잡해서 일단 재은이 서버랑 통신하는 것 부터 처리하고 만들 예정

<br/>

### 📝 논의사항

검색 기록 조회, 삭제 기능만 구현 했고 이거 로컬에서 사용해보려면 redis 서버 설치해야해서 해보고 싶으면 나한테 말해주셔
일단 내가 로컬에서 돌아가는지 테스트는 마친 상황

검색 기능은 재은이 서버랑 연결하고 구현하겠음


