### PR TITLE
코스 도메인 속성 변경 및 어노테이션 변경

### DIFF
--- a/src/main/java/footlogger/footlog/converter/CourseConverter.java
+++ b/src/main/java/footlogger/footlog/converter/CourseConverter.java
@@ -21,9 +21,6 @@ public class CourseConverter {
 
     public CourseResponseDTO toResponseDTO(Course course, Boolean isSave) {
         String area = areaConverter.getAreaNameByCode(course.getAreaCode());
-//        List<String> images = course.getImages().stream()
-//                .map(CourseImage::getImage)
-//                .toList();
 
         return CourseResponseDTO.builder()
                 .course_id(course.getId())
@@ -35,9 +32,6 @@ public class CourseConverter {
     }
 
     public CourseDetailDTO toDetailDTO(Course course, Boolean isSave, Boolean isComplete) {
-//        List<String> images = course.getImages().stream()
-//                .map(CourseImage::getImage)
-//                .toList();
 
         return CourseDetailDTO.builder()
                 .course_id(course.getId())
@@ -45,7 +39,6 @@ public class CourseConverter {
                 .image(course.getImage())
                 .summary(course.getContent())
                 .address(course.getAddress())
-                .tel(course.getPhoneNum())
                 .isSave(isSave)
                 .isComplete(isComplete)
                 .build();

--- a/src/main/java/footlogger/footlog/domain/Course.java
+++ b/src/main/java/footlogger/footlog/domain/Course.java
@@ -17,7 +17,6 @@ import java.util.List;
 @AllArgsConstructor
 public class Course {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "course_id")
     private Long id;
 
@@ -34,19 +33,17 @@ public class Course {
     private List<CheckCourse> checkCourseList = new ArrayList<>();
 
     private String image;
-    private String location;
     private String name;
+    @Lob
+    @Column(name = "content", columnDefinition = "TEXT")
     private String content;
     private String phoneNum;
-    private String charge;
-    private String openDay;
-    private String homepage;
+    private String phoneName;
     private int areaCode;
     private int sigunguCode;
     private String address;
-
-
-
+    private String createdTime;
+    private String modifiedTime;
     //저장된 수
     @Formula("(SELECT COUNT(sc.user_id) FROM save_course sc WHERE sc.course_id = course_id)")
     private int totalSaves;

--- a/src/main/java/footlogger/footlog/repository/CourseRepository.java
+++ b/src/main/java/footlogger/footlog/repository/CourseRepository.java
@@ -18,4 +18,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     //지역 코드에 맞게 코스들을 저장수 순으로 불러옴
     @Query("SELECT c FROM Course c WHERE c.areaCode = :areaCode ORDER BY c.totalSaves")
     List<Course> findByAreaCode(@Param("areaCode") Long areaCode);
+
+    @Query("SELECT c FROM Course c ORDER BY c.totalSaves LIMIT :total")
+    List<Course> findAllOrderByTotalSaves(@Param("total") Integer total);
 }

--- a/src/main/java/footlogger/footlog/repository/RecommendRepository.java
+++ b/src/main/java/footlogger/footlog/repository/RecommendRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 
 public interface RecommendRepository extends JpaRepository<RecommendCourse, Long> {
     List<RecommendCourse> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/footlogger/footlog/service/CourseService.java
+++ b/src/main/java/footlogger/footlog/service/CourseService.java
@@ -129,6 +129,10 @@ public class CourseService {
         User user = userRepository.findByAccessToken(token)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
+        //기존에 저장되어 있는 코스가 있으면 삭제
+        recommendRepository.deleteByUserId(user.getId());
+
+        //플라스크 서버에서 코스 분석 후 반환
         List<Long> courseIds = recommendSystem.getRecommendations(request);
 
         List<Course> courses = courseIds.stream()
@@ -145,25 +149,6 @@ public class CourseService {
                         .toResponseDTO(course, saveService.getSaveStatus(course.getId(), user.getId())))
                 .collect(Collectors.toList());
     }
-
-    //테스트
-//    public List<Long> analyzePreference(String token, PreferenceRequestBody request) {
-//        User user = userRepository.findByAccessToken(token)
-//                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
-//
-//        List<Long> courseIds = recommendSystem.getRecommendations(request);
-//
-//        List<Course> courses = courseIds.stream()
-//                .map(courseRepository::findById)
-//                .filter(Optional::isPresent)
-//                .map(Optional::get)
-//                .toList();
-//
-//        //서버에 저장
-//        saveCourses(courses, user);
-//
-//        return courseIds;
-//    }
 
     //플라스크 서버에서 받아온 코스 저장
     public void saveCourses(List<Course> courses, User user) {

--- a/src/main/java/footlogger/footlog/web/controller/CourseController.java
+++ b/src/main/java/footlogger/footlog/web/controller/CourseController.java
@@ -139,6 +139,15 @@ public class CourseController {
         return ApiResponse.onSuccess(courseService.getCompleteCourse(tokenWithoutBearer));
     }
 
+    @Operation(summary = "최근 핫한 코스 조회")
+    @GetMapping(value = "/hot")
+    public ApiResponse<List<CourseResponseDTO>> getHotCourses(
+            @RequestHeader("Authorization") String token
+    ) {
+        String tokenWithoutBearer = token.substring(7);
+        return ApiResponse.onSuccess(courseService.getHotCourses(tokenWithoutBearer));
+    }
+
     @Operation( summary = "이미지 업로드 테스트")
     @PostMapping(value = "/s3/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> s3Upload(@RequestParam(value = "image") MultipartFile image) {


### PR DESCRIPTION
## 연관 이슈

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->

<br/>

## ✅ 작업 내용

- [x] CourseConverter 필요 없는 주석 제거
- [x] Course 도메인 변경
1. @GeneratedValue 어노테이션 삭제 : 투어 api에서 주는 id값으로 해야하는데 자동으로 값을 잡아버려 삭제
2. content에 Lob 어노테이션 추가 : 투어 api에서 주는 내용이 너무 길어서 Lob을 이용해 용량을 늘림
3. createTime, modifiedTime 추가 : 나중에 투어 api에서 값의 변경이 있을경우 동기화 용도


--------
Commit 6c1c3c0

- [x] 기존 분석 내용 삭제 기능 추가 

이미 ai분석 추천을 받은 적이 있고, 그 후에 다시 재분석을 시도하면 기존에 추천 받았던 내용들이 사라지지 않고 있었습니다.
이를 먼저 삭제를 한 후 다시 새롭게 추천 받게 코드를 추가 했습니다.

 --------
Commit : 4c556c0 

- [x] 전체 코스 조회 기능 추가 

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/95b338e5-b4d2-41b8-9663-5ea53f3e3f52">

지역 코드 0을 입력 시 전체 코스에서 50개를 저장된 수가 많은 순으로 가져옴 



- [x] 최근 핫한 코스 조회 기능 추가

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/1716f462-4176-4ca9-a7b9-18bd5e3dfbe3">

전체 코스에서 저장된 수가 많은 10개를 반환함  
<br/>

### 📝 논의사항

1. 전화번호, 전화명은 일단 반환 작업 전 이후에 작업으로 추가 예정
2. 우리는 프론트에서 페이징기능을 사용하지 않는다 했기때문에 전체 코스를 줄 때 182개 코스를 전부 주기에 서버의 메모리 부담이 걱정됩니다. 그래서 일단 50개만 주는 거로 설정해놨습니다만 더 필요하다면 논의해봐야 할 것 같습니다.
