### PR TITLE
[Feat] 코스 검색 기능 추가

### DIFF
--- a/src/main/java/footlogger/footlog/config/RedisConfig.java
+++ b/src/main/java/footlogger/footlog/config/RedisConfig.java
@@ -37,4 +37,16 @@ public class RedisConfig {
 
         return redisTemplate;
     }
+
+    @Bean
+    public RedisTemplate<String, Long> CourseRedis() {
+        RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(Long.class));
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Long.class));
+
+        return redisTemplate;
+    }
 }

--- a/src/main/java/footlogger/footlog/config/SecurityConfig.java
+++ b/src/main/java/footlogger/footlog/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/swagger-ui/**", "/swagger/**", "/swagger-resources/**", "/swagger-ui.html"
-            ,"/course/**", "/log/**", "/user/**", "/v3/api-docs/**"
+            ,"/course/**", "/log/**", "/search/**", "/user/**", "/v3/api-docs/**"
     };
 
 //    @Bean

--- a/src/main/java/footlogger/footlog/repository/CourseRepository.java
+++ b/src/main/java/footlogger/footlog/repository/CourseRepository.java
@@ -21,4 +21,16 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     @Query("SELECT c FROM Course c ORDER BY c.totalSaves LIMIT :total")
     List<Course> findAllOrderByTotalSaves(@Param("total") Integer total);
+
+    //검색어와 이름이 매칭되는 코스 불러오기
+    @Query("SELECT c FROM Course c WHERE c.name LIKE %:keyword% ORDER BY c.totalSaves LIMIT :limit")
+    List<Course> findByNameKeyword(@Param("keyword") String keyword, @Param("limit") Integer limit);
+
+    //검색어와 주소가 매칭되는 코스 불러오기
+    @Query("SELECT c FROM Course c WHERE c.address LIKE %:keyword% ORDER BY c.totalSaves LIMIT :limit")
+    List<Course> findByAddressKeyword(@Param("keyword") String keyword, @Param("limit") Integer limit);
+
+    //검색어와 내용가 매칭되는 코스 불러오기
+    @Query("SELECT c FROM Course c WHERE c.content LIKE %:keyword% ORDER BY c.totalSaves LIMIT :limit")
+    List<Course> findByContentKeyword(@Param("keyword") String keyword, @Param("limit") Integer limit);
 }

--- a/src/main/java/footlogger/footlog/service/CourseService.java
+++ b/src/main/java/footlogger/footlog/service/CourseService.java
@@ -39,6 +39,7 @@ public class CourseService {
     private final RecommendRepository recommendRepository;
     private final LogService logService;
     private final RedisTemplate<String, Long> redisTemplate;
+    private final SearchService searchService;
 
     //지역기반으로 코스를 받아 옴
     public List<CourseResponseDTO> getByAreaName(String token, Long areaCode) {
@@ -217,9 +218,11 @@ public class CourseService {
     }
 
     //코스 검색 기능
-    public List<CourseResponseDTO> getCourseByKeyowrd(String token, String keyword) {
+    public List<CourseResponseDTO> getCourseByKeyword(String token, String keyword) {
         User user = userRepository.findByAccessToken(token)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        searchService.saveRecentSearchLog(user, keyword);
 
         //검색 결과의 최대 개수
         int totalCount = 20;

--- a/src/main/java/footlogger/footlog/service/SearchService.java
+++ b/src/main/java/footlogger/footlog/service/SearchService.java
@@ -22,16 +22,14 @@ public class SearchService {
     private final RedisTemplate<String, SearchLog> redisTemplate;
 
     //검색어 저장 기능
-    public void saveRecentSearchLog(String token, String keword) {
-        User user = userRepository.findByAccessToken(token)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+    public void saveRecentSearchLog(User user, String keyword) {
 
         String now = LocalDateTime.now().toString();
 
         //key값 : SearchLog + 유저 id 값
         String key = "SearchLog" + user.getId();
         SearchLog value = SearchLog.builder()
-                .log(keword)
+                .log(keyword)
                 .createdAt(now)
                 .build();
 

--- a/src/main/java/footlogger/footlog/web/controller/CourseController.java
+++ b/src/main/java/footlogger/footlog/web/controller/CourseController.java
@@ -148,6 +148,16 @@ public class CourseController {
         return ApiResponse.onSuccess(courseService.getHotCourses(tokenWithoutBearer));
     }
 
+    @Operation(summary = "코스 검색 api")
+    @GetMapping(value = "/search/{keyword}")
+    public ApiResponse<List<CourseResponseDTO>> searchCourse(
+            @RequestHeader("Authorization") String token,
+            @PathVariable(value = "keyword") String keyword
+    ) {
+        String tokenWithoutBearer = token.substring(7);
+        return ApiResponse.onSuccess(courseService.getCourseByKeyowrd(tokenWithoutBearer, keyword));
+    }
+
     @Operation( summary = "이미지 업로드 테스트")
     @PostMapping(value = "/s3/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> s3Upload(@RequestParam(value = "image") MultipartFile image) {

--- a/src/main/java/footlogger/footlog/web/controller/CourseController.java
+++ b/src/main/java/footlogger/footlog/web/controller/CourseController.java
@@ -158,6 +158,15 @@ public class CourseController {
         return ApiResponse.onSuccess(courseService.getCourseByKeyowrd(tokenWithoutBearer, keyword));
     }
 
+    @Operation(summary = "최근 확인한 코드")
+    @GetMapping(value = "/recent")
+    public ApiResponse<List<CourseResponseDTO>> getRecentCourse(
+            @RequestHeader("Authorization") String token
+    ) {
+        String tokenWithoutBearer = token.substring(7);
+        return ApiResponse.onSuccess(courseService.getRecentCourse(tokenWithoutBearer));
+    }
+
     @Operation( summary = "이미지 업로드 테스트")
     @PostMapping(value = "/s3/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> s3Upload(@RequestParam(value = "image") MultipartFile image) {

--- a/src/main/java/footlogger/footlog/web/controller/CourseController.java
+++ b/src/main/java/footlogger/footlog/web/controller/CourseController.java
@@ -148,17 +148,17 @@ public class CourseController {
         return ApiResponse.onSuccess(courseService.getHotCourses(tokenWithoutBearer));
     }
 
-    @Operation(summary = "코스 검색 api")
-    @GetMapping(value = "/search/{keyword}")
-    public ApiResponse<List<CourseResponseDTO>> searchCourse(
-            @RequestHeader("Authorization") String token,
-            @PathVariable(value = "keyword") String keyword
-    ) {
-        String tokenWithoutBearer = token.substring(7);
-        return ApiResponse.onSuccess(courseService.getCourseByKeyowrd(tokenWithoutBearer, keyword));
-    }
+//    @Operation(summary = "코스 검색 api")
+//    @GetMapping(value = "/search/{keyword}")
+//    public ApiResponse<List<CourseResponseDTO>> searchCourse(
+//            @RequestHeader("Authorization") String token,
+//            @PathVariable(value = "keyword") String keyword
+//    ) {
+//        String tokenWithoutBearer = token.substring(7);
+//        return ApiResponse.onSuccess(courseService.getCourseByKeyowrd(tokenWithoutBearer, keyword));
+//    }
 
-    @Operation(summary = "최근 확인한 코드")
+    @Operation(summary = "최근 확인한 코스")
     @GetMapping(value = "/recent")
     public ApiResponse<List<CourseResponseDTO>> getRecentCourse(
             @RequestHeader("Authorization") String token
@@ -167,12 +167,12 @@ public class CourseController {
         return ApiResponse.onSuccess(courseService.getRecentCourse(tokenWithoutBearer));
     }
 
-    @Operation( summary = "이미지 업로드 테스트")
-    @PostMapping(value = "/s3/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> s3Upload(@RequestParam(value = "image") MultipartFile image) {
-        String profileImage = s3ImageService.upload(image);
-        return ResponseEntity.ok(profileImage);
-    }
+//    @Operation( summary = "이미지 업로드 테스트")
+//    @PostMapping(value = "/s3/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+//    public ResponseEntity<?> s3Upload(@RequestParam(value = "image") MultipartFile image) {
+//        String profileImage = s3ImageService.upload(image);
+//        return ResponseEntity.ok(profileImage);
+//    }
 
 
 }

--- a/src/main/java/footlogger/footlog/web/controller/SearchController.java
+++ b/src/main/java/footlogger/footlog/web/controller/SearchController.java
@@ -45,15 +45,13 @@ public class SearchController {
                 .build());
     }
 
-    @Operation(summary = "검색")
+    @Operation(summary = "코스 검색")
     @GetMapping("/course/{keyword}")
     public ApiResponse<List<CourseResponseDTO>> searchCourse(
             @RequestHeader("Authorization") String token,
-            @PathVariable("keyword") String keyword
+            @PathVariable(value = "keyword") String keyword
     ) {
         String tokenWithoutBearer = token.substring(7);
-        searchService.saveRecentSearchLog(token, keyword);
-
-        return ApiResponse.onSuccess(courseService.getByAreaName(tokenWithoutBearer, 1L));
+        return ApiResponse.onSuccess(courseService.getCourseByKeyword(tokenWithoutBearer, keyword));
     }
 }


### PR DESCRIPTION
## 연관 이슈

<br/>

## 개요

코스 검색 기능 추가

<br/>

## ✅ 작업 내용

Commit : [2444b57](https://github.com/Foot-Log/footlog-server/pull/59/commits/2444b57f3c1ee482b2aa248f709598ac9a64315b)
- [x] 코스 검색 기능 추가

<img width="1332" alt="image" src="https://github.com/user-attachments/assets/47053359-a75f-45cb-ab48-831264ed495b">
공원 검색 시 결과

1. 코스의 이름에서 매칭되는 코스를 가져옴
2. 코스의 주소에서 매칭되는 코스를 가져옴
3. 코스의 내용에서 매칭되는 코스를 가져옴

이름, 주소, 내용순으로 우선순위를 두고 코스를 찾으며 다 합쳐서 최대 20개까지 반환가능

----------------------------------

Commit : [6feb1c0](https://github.com/Foot-Log/footlog-server/pull/59/commits/6feb1c0c6728796107a5e061f94b5c0452190002)
- [x] 최근 확인한 코스 기능 추가

<img width="1413" alt="image" src="https://github.com/user-attachments/assets/b51f0814-be1e-40d6-a8f1-82b5f7d559de">

코스 상세정보 확인 api를 사용하면 동시에 최근 확인한 코스로 등록함 (Redis 이용)
만약 최근확인한 코스정보 필요하면 
CourseService의 getRecentCourse 함수 이용하면 됨

----------------------------
Commit : [aa7ea91](https://github.com/Foot-Log/footlog-server/pull/59/commits/aa7ea9186edc5ce8f68f39dbabd22d8ced1878be)
-[x] 코스 검색 기능 수정

1. 코스 검색 api course에서 search 컨트롤러로 변경
2. 코스 검색 시 검색어를 저장 해놔야 하는데 이 코드가 누락되어있어 추가
3. SecurityConfig에 search api가 누락되어있어 이를 추가

<br/>

### 📝 논의사항

20개 이상으로 늘려야할지,
검색어에 따라 적절하지 않은 검색 결과를 낼 때가 있어서... 
일단 프론트 작업을 위해 기능 자체는 만들어두고 계속해서 업데이트 해볼 예정

Redis 이용해서 최근 확인 코스 정보 저장해둔 것에 대해 질문이 있으면 직접 연락으로 알려드립니다
