### PR TITLE
[Feat] 시군구 정보 조회 기능 추가

### DIFF
--- a/src/main/java/footlogger/footlog/config/RedisConfig.java
+++ b/src/main/java/footlogger/footlog/config/RedisConfig.java
@@ -27,18 +27,6 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, SearchLog> SearchLogRedis() {
-        RedisTemplate<String, SearchLog> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(SearchLog.class));
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(SearchLog.class));
-
-        return redisTemplate;
-    }
-
-    @Bean
     public RedisTemplate<String, Long> CourseRedis() {
         RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());

--- a/src/main/java/footlogger/footlog/converter/AreaConverter.java
+++ b/src/main/java/footlogger/footlog/converter/AreaConverter.java
@@ -1,6 +1,8 @@
 package footlogger.footlog.converter;
 
+import footlogger.footlog.domain.Sigungu;
 import footlogger.footlog.web.dto.response.AreaCodeDTO;
+import footlogger.footlog.web.dto.response.SigunguCodeDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -66,6 +68,14 @@ public class AreaConverter {
         }
 
         return areaCodeDTOList;
+    }
+
+    public SigunguCodeDTO getSigunguCodeDTOByCodes(Sigungu sigungu) {
+        return SigunguCodeDTO.builder()
+                .areaCode(sigungu.getAreaCode())
+                .sigunguCode(sigungu.getSigunguCode())
+                .sigunguName(sigungu.getSigunguName())
+                .build();
     }
 }
 

--- a/src/main/java/footlogger/footlog/converter/CourseConverter.java
+++ b/src/main/java/footlogger/footlog/converter/CourseConverter.java
@@ -25,7 +25,7 @@ public class CourseConverter {
         return CourseResponseDTO.builder()
                 .course_id(course.getId())
                 .image(course.getImage())
-                .area(area)
+                .area(course.getAddress())
                 .name(course.getName())
                 .isSave(isSave)
                 .build();

--- a/src/main/java/footlogger/footlog/converter/SearchLogConverter.java
+++ b/src/main/java/footlogger/footlog/converter/SearchLogConverter.java
@@ -9,7 +9,7 @@ public class SearchLogConverter {
 
     public static SearchLogDTO toDTO(String keyword) {
         return SearchLogDTO.builder()
-                .log(keyword)
+                .keyword(keyword)
                 .build();
     }
 }

--- a/src/main/java/footlogger/footlog/converter/SearchLogConverter.java
+++ b/src/main/java/footlogger/footlog/converter/SearchLogConverter.java
@@ -7,10 +7,9 @@ import java.util.List;
 
 public class SearchLogConverter {
 
-    public static SearchLogDTO toDTO(SearchLog searchLog) {
+    public static SearchLogDTO toDTO(String keyword) {
         return SearchLogDTO.builder()
-                .log(searchLog.getLog())
-                .CreatedAt(searchLog.getCreatedAt())
+                .log(keyword)
                 .build();
     }
 }

--- a/src/main/java/footlogger/footlog/domain/Sigungu.java
+++ b/src/main/java/footlogger/footlog/domain/Sigungu.java
@@ -1,0 +1,27 @@
+package footlogger.footlog.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Sigungu {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int areaCode;
+
+    private int sigunguCode;
+
+    private String sigunguName;
+}

--- a/src/main/java/footlogger/footlog/repository/SigunguRepository.java
+++ b/src/main/java/footlogger/footlog/repository/SigunguRepository.java
@@ -1,0 +1,10 @@
+package footlogger.footlog.repository;
+
+import footlogger.footlog.domain.Sigungu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SigunguRepository extends JpaRepository<Sigungu, Long> {
+    List<Sigungu> findByAreaCodeAndSigunguCode(Long areaCode, Long sigunguCode);
+}

--- a/src/main/java/footlogger/footlog/service/AreaService.java
+++ b/src/main/java/footlogger/footlog/service/AreaService.java
@@ -1,7 +1,10 @@
 package footlogger.footlog.service;
 
 import footlogger.footlog.converter.AreaConverter;
+import footlogger.footlog.domain.Sigungu;
+import footlogger.footlog.repository.SigunguRepository;
 import footlogger.footlog.web.dto.response.AreaCodeDTO;
+import footlogger.footlog.web.dto.response.SigunguCodeDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -12,8 +15,17 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AreaService {
     private final AreaConverter areaConverter;
+    private final SigunguRepository sigunguRepository;
 
     public List<AreaCodeDTO> getAreaCodes() {
         return areaConverter.getAreaCodeDTOByCodes();
+    }
+
+    public List<SigunguCodeDTO> getSigunguInfo() {
+        List<Sigungu> sigungus = sigunguRepository.findAll();
+
+        return sigungus.stream()
+                .map(areaConverter::getSigunguCodeDTOByCodes)
+                .toList();
     }
 }

--- a/src/main/java/footlogger/footlog/service/CourseService.java
+++ b/src/main/java/footlogger/footlog/service/CourseService.java
@@ -271,6 +271,8 @@ public class CourseService {
         //key값 : Course + 유저 id 값
         String key = "Course" + user.getId();
 
+        redisTemplate.opsForList().remove(key, 1, courseId);
+
         Long size = redisTemplate.opsForList().size(key);
 
         //10개를 넘을 경우 가장 오래된 데이터 삭제

--- a/src/main/java/footlogger/footlog/service/CourseService.java
+++ b/src/main/java/footlogger/footlog/service/CourseService.java
@@ -46,9 +46,9 @@ public class CourseService {
         User user = userRepository.findByAccessToken(token)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
-        //지역 전체를 뜻하는 0번을 입력할 경우 전체 지역에서 50개를 가져옴
+        //지역 전체를 뜻하는 0번을 입력할 경우 전체 코스를 가져옴
         if (areaCode == 0) {
-            return courseRepository.findAllOrderByTotalSaves(50).stream()
+            return courseRepository.findAllOrderByTotalSaves(182).stream()
                     .map(course -> courseConverter
                             .toResponseDTO(course, saveService.getSaveStatus(course.getId(), user.getId())))
                     .toList();

--- a/src/main/java/footlogger/footlog/service/SearchService.java
+++ b/src/main/java/footlogger/footlog/service/SearchService.java
@@ -53,12 +53,11 @@ public class SearchService {
                 .collect(Collectors.toList());
     }
 
-    public Long deleteRecentSearchLog(String token, SearchLogDTO request) {
+    public Long deleteRecentSearchLog(String token, String keyword) {
         User user = userRepository.findByAccessToken(token)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
         String key = "SearchLog" + user.getId();
-        String keyword = request.getLog();
 
         long count = redisTemplate.opsForList().remove(key, 1, keyword);
 

--- a/src/main/java/footlogger/footlog/utils/SigunguResponse.java
+++ b/src/main/java/footlogger/footlog/utils/SigunguResponse.java
@@ -1,0 +1,49 @@
+package footlogger.footlog.utils;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SigunguResponse {
+        private Response response;
+
+    @Data
+        public static class Response {
+            private Header header;
+            private Body body;
+
+            // getter, setter
+        }
+    @Data
+        public static class Header {
+            private String resultCode;
+            private String resultMsg;
+
+            // getter, setter
+        }
+    @Data
+        public static class Body {
+            private Items items;
+            private int numOfRows;
+            private int pageNo;
+            private int totalCount;
+            // getter, setter
+        }
+    @Data
+        public static class Items {
+            private List<Item> item;
+
+            // getter, setter
+        }
+    @Data
+        public static class Item {
+            private String code; // 'code' 필드
+            private String name; // 'name' 필드
+            private String rnum;
+            // getter, setter
+        }
+
+        // getter, setter
+    }
+

--- a/src/main/java/footlogger/footlog/web/controller/SearchController.java
+++ b/src/main/java/footlogger/footlog/web/controller/SearchController.java
@@ -37,14 +37,14 @@ public class SearchController {
     }
 
     @Operation(summary = "검색어 삭제")
-    @PatchMapping("/delete")
+    @PatchMapping("/delete/{keyword}")
     public ApiResponse<CourseCountDTO> deleteSearchLog(
             @RequestHeader("Authorization") String token,
-            @RequestBody SearchLogDTO requestBody
+            @PathVariable(value = "keyword") String keyword
     ) {
         String tokenWithoutBearer = token.substring(7);
         return ApiResponse.onSuccess(CourseCountDTO.builder()
-                        .Count(searchService.deleteRecentSearchLog(tokenWithoutBearer, requestBody))
+                        .Count(searchService.deleteRecentSearchLog(tokenWithoutBearer, keyword))
                 .build());
     }
 

--- a/src/main/java/footlogger/footlog/web/controller/SearchController.java
+++ b/src/main/java/footlogger/footlog/web/controller/SearchController.java
@@ -2,11 +2,13 @@ package footlogger.footlog.web.controller;
 
 import footlogger.footlog.payload.ApiResponse;
 import footlogger.footlog.repository.CourseRepository;
+import footlogger.footlog.service.AreaService;
 import footlogger.footlog.service.CourseService;
 import footlogger.footlog.service.SearchService;
 import footlogger.footlog.web.dto.response.CourseCountDTO;
 import footlogger.footlog.web.dto.response.CourseResponseDTO;
 import footlogger.footlog.web.dto.response.SearchLogDTO;
+import footlogger.footlog.web.dto.response.SigunguCodeDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ public class SearchController {
     private final SearchService searchService;
     private final CourseService courseService;
     private final CourseRepository courseRepository;
+    private final AreaService areaService;
 
     @Operation(summary = "최근 검색어 조회")
     @GetMapping("/recent")
@@ -53,5 +56,13 @@ public class SearchController {
     ) {
         String tokenWithoutBearer = token.substring(7);
         return ApiResponse.onSuccess(courseService.getCourseByKeyword(tokenWithoutBearer, keyword));
+    }
+
+    @Operation(summary = "시군구 정보 전체 조회")
+    @GetMapping(value = "sigungu_code")
+    public ApiResponse<List<SigunguCodeDTO>> getSigunguInfo(
+            @RequestHeader("Authorization") String token
+    ) {
+        return ApiResponse.onSuccess(areaService.getSigunguInfo());
     }
 }

--- a/src/main/java/footlogger/footlog/web/dto/response/SearchLogDTO.java
+++ b/src/main/java/footlogger/footlog/web/dto/response/SearchLogDTO.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 @Builder
 public class SearchLogDTO {
-    private String log;
+    private String keyword;
 }

--- a/src/main/java/footlogger/footlog/web/dto/response/SearchLogDTO.java
+++ b/src/main/java/footlogger/footlog/web/dto/response/SearchLogDTO.java
@@ -7,5 +7,4 @@ import lombok.Getter;
 @Builder
 public class SearchLogDTO {
     private String log;
-    private String CreatedAt;
 }

--- a/src/main/java/footlogger/footlog/web/dto/response/SigunguCodeDTO.java
+++ b/src/main/java/footlogger/footlog/web/dto/response/SigunguCodeDTO.java
@@ -1,0 +1,12 @@
+package footlogger.footlog.web.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class SigunguCodeDTO {
+    private int sigunguCode;
+    private int areaCode;
+    private String sigunguName;
+}


### PR DESCRIPTION
## 연관 이슈


<br/>

## 개요

시군구 정보 조회 기능 추가

<br/>

## ✅ 작업 내용

[b786051](https://github.com/Foot-Log/footlog-server/pull/61/commits/b7860517a748a51542f0ba2272ab4d619caff95b)
- [x] 시군구 정보 조회 기능 추가
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/4fd7a091-976f-4fde-879a-e349b49e4b30">

검색 시 정보조회를 위한 시군구 정보 조회기능 추가 모든 시군구 데이터를 가져옴
DB 테이블에 시군구 정보 저장해두는 엔티티 추가 및 데이터 추가

원래는 tour API에서 그때 그때 정보를 가져오려했지만
그 방식으로 운용하면 api 요청이 검색바를 누를때마다 날려져서 비효율적이라 생각해 그냥 우리 DB에 담아버렸음

검색에 필요한 정보이기 때문에 SearchController에서 작동하는 api

-------------------------

[fd6b39a](https://github.com/Foot-Log/footlog-server/pull/61/commits/fd6b39ab6284d14a0318cd8e57f85aaa53cca3fb)
- [x] 코스 확인 기록, 검색 기록 중복 방지

<img width="1387" alt="image" src="https://github.com/user-attachments/assets/b006874c-e6c9-4fae-ad39-13bfce90ff6c">

코스 확인 기록, 검색 기록 중복되는 상황이 발생해 이를 제거
검색 기록에서 검색 시간을 넣어버려서 같은 검색어여도 시간이 달라 다른거로 취급해버리는 상황 발생
그래서 그냥 검색 시간을 없애버림

--------------------

[ef2a9f0](https://github.com/Foot-Log/footlog-server/pull/61/commits/ef2a9f079236ef7a59eb742e690cf90a08c83516)

- [x] 코스 정보 반환 시 주소 반환
<img width="1402" alt="image" src="https://github.com/user-attachments/assets/47004411-623d-45c8-9e15-d9d8ac9eb87e">

코스 정보 반환할 때 지역명만 주고 주소를 안주게 설정해서 이를 수정 
경상북도 -> 경상북도 문경시 문경읍 새재로 932

-----------------
[19f91ea](https://github.com/Foot-Log/footlog-server/pull/61/commits/19f91eaade0e97aaf6580ad9d1505b7251a19301)
- [x] [코스 삭제 키워드 입력 방식 변경
<img width="1425" alt="image" src="https://github.com/user-attachments/assets/93c698b4-8b8e-49e4-a620-a76048b8ad88">

RequestBody -> PathVariable 로 변경 받는 값 이름도 플로깅 로그와 혼동을 피하기 위해 log에서 keyword로 변경
<br/>

### 📝 논의사항

지역 전체 코스 그냥 182개 불러오는거로 돌려보겠습니다.
