### PR TITLE
[Feat] 시군구 정보 반환 변경

### DIFF
--- a/src/main/java/footlogger/footlog/converter/AreaConverter.java
+++ b/src/main/java/footlogger/footlog/converter/AreaConverter.java
@@ -71,10 +71,12 @@ public class AreaConverter {
     }
 
     public SigunguCodeDTO getSigunguCodeDTOByCodes(Sigungu sigungu) {
+        String areaName = getAreaNameByCode(sigungu.getAreaCode());
+
         return SigunguCodeDTO.builder()
-                .areaCode(sigungu.getAreaCode())
-                .sigunguCode(sigungu.getSigunguCode())
+                .sigunguId(sigungu.getId())
                 .sigunguName(sigungu.getSigunguName())
+                .withArea(areaName + " " + sigungu.getSigunguName())
                 .build();
     }
 }

--- a/src/main/java/footlogger/footlog/service/CourseService.java
+++ b/src/main/java/footlogger/footlog/service/CourseService.java
@@ -46,6 +46,7 @@ public class CourseService {
     private final RedisTemplate<String, Long> redisTemplate;
     private final SearchService searchService;
     private final TourApi tourApi;
+    private final SigunguRepository sigunguRepository;
 
     //지역기반으로 코스를 받아 옴
     public List<CourseResponseDTO> getByAreaName(String token, Long areaCode) {
@@ -309,9 +310,15 @@ public class CourseService {
     }
 
     //시군구별 코스 조회
-    public List<CourseResponseDTO> getSigunguCourse(String token, int areaCode, int sigunguCode) {
+    public List<CourseResponseDTO> getSigunguCourse(String token, Long sigunguId) {
         User user = userRepository.findByAccessToken(token)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        Sigungu sigungu = sigunguRepository.findById(sigunguId)
+                .orElseThrow(() -> new IllegalArgumentException("시군구를 찾을 수 없습니다."));
+
+        int areaCode = sigungu.getAreaCode();
+        int sigunguCode = sigungu.getSigunguCode();
 
         String jsonResponse = tourApi.getSigunguCourse(areaCode, sigunguCode);
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/footlogger/footlog/web/controller/CourseController.java
+++ b/src/main/java/footlogger/footlog/web/controller/CourseController.java
@@ -168,14 +168,13 @@ public class CourseController {
     }
 
     @Operation(summary = "시군구 별 코스 조회")
-    @GetMapping(value = "/sigungu")
+    @GetMapping(value = "/sigungu/{sigungu_id}")
     public ApiResponse<List<CourseResponseDTO>> getSigunguCourse(
             @RequestHeader("Authorization") String token,
-            @RequestParam("area_code") int areaCode,
-            @RequestParam("sigungu_code") int sigunguCode
+            @PathVariable("sigungu_id") Long sigunguId
     ) {
         String tokenWithoutBearer = token.substring(7);
-        return ApiResponse.onSuccess(courseService.getSigunguCourse(tokenWithoutBearer, areaCode, sigunguCode));
+        return ApiResponse.onSuccess(courseService.getSigunguCourse(tokenWithoutBearer, sigunguId));
     }
 
 //    @Operation( summary = "이미지 업로드 테스트")

--- a/src/main/java/footlogger/footlog/web/dto/response/SigunguCodeDTO.java
+++ b/src/main/java/footlogger/footlog/web/dto/response/SigunguCodeDTO.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Builder
 @Getter
 public class SigunguCodeDTO {
-    private int sigunguCode;
-    private int areaCode;
+    private Long sigunguId;
     private String sigunguName;
+    private String withArea;
 }


### PR DESCRIPTION
## 연관 이슈


<br/>

## 개요


<br/>

## ✅ 작업 내용

- [x] 시군구 코스 반환값 변경
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/f891844f-b32e-4a80-a7f5-402ee6da62cd">

코드값이 아닌 시군구 아이디 값 하나로 변경
지역이름과 시군구이름이 같이 있는 정보 추가

- [x] 시군구 별 코스 조회 기능 수정
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/f7e062a6-c9f6-4617-8652-4b8063f6c87e">

지역코드, 시군구 코드로 코스를 조회하지 않고
시군구 id 하나로 코스를 조회

<br/>

### 📝 논의사항


