### PR TITLE
[Feature] 유저 스탬프 로직 구현

### DIFF
--- a/src/main/java/footlogger/footlog/converter/UserConverter.java
+++ b/src/main/java/footlogger/footlog/converter/UserConverter.java
@@ -9,17 +9,33 @@ import java.util.stream.Collectors;
 
 public class UserConverter {
     public static UserResponseDto.UserInfoDto toUserInfo(User user) {
+        long currentStampCount = user.getStampCount() != null ? user.getStampCount() : 0;
+
+        String levelName = getLevelName(currentStampCount);
+
+        long stampsInCurrentLevel = (currentStampCount - 1) % 5 + 1;
+
         return UserResponseDto.UserInfoDto.builder()
                 .kakaoId(user.getKakaoId())
                 .nickname(user.getNickname())
-                .level(user.getLevel())
-                .stampCount(user.getStampCount())
+                .level(levelName)
+                .stampCount(stampsInCurrentLevel)
                 .profileImg(user.getProfileImg())
-//                .saveCourseList(user.getSaveCourseList().stream()
-//                        .map(UserConverter::toSaveCourse).collect(Collectors.toList()))
-//                .checkCourseList(user.getCheckCourseList().stream()
-//                        .map(UserConverter::toCheckCourse).collect(Collectors.toList()))
                 .build();
+    }
+
+    public static String getLevelName(long stampCount){
+        if (stampCount <= 5) {
+            return "새싹 플로거";
+        } else if (stampCount <= 10) {
+            return "초보 플로거";
+        } else if (stampCount <= 15) {
+            return "중수 플로거";
+        } else if (stampCount <= 20) {
+            return "고수 플로거";
+        } else {
+            return "베스트 플로거";
+        }
 
     }
     public static UserResponseDto.SaveCourseDto toSaveCourse(SaveCourse saveCourse) {

--- a/src/main/java/footlogger/footlog/domain/User.java
+++ b/src/main/java/footlogger/footlog/domain/User.java
@@ -41,4 +41,8 @@ public class User {
     private String refreshToken;
     @Setter
     private String accessToken;
+
+    public void setStampCount(long stampCount) {
+        this.stampCount = stampCount;
+    }
 }

--- a/src/main/java/footlogger/footlog/service/CourseService.java
+++ b/src/main/java/footlogger/footlog/service/CourseService.java
@@ -132,8 +132,16 @@ public class CourseService {
                 .course(course)
                 .user(user)
                 .build();
+        logRepository.save(log);
 
-        return logRepository.save(log).getId();
+        long currentStampCount = user.getStampCount() != null ? user.getStampCount() : 0;
+        long updatedStampCount = currentStampCount + 1;
+
+        user.setStampCount(updatedStampCount);
+        userRepository.save(user);
+
+        return log.getId();
+
     }
 
     //플라스크 서버로 분석요청 보낸 후 코스id 받아옴

--- a/src/main/java/footlogger/footlog/service/KakaoService.java
+++ b/src/main/java/footlogger/footlog/service/KakaoService.java
@@ -186,7 +186,7 @@ public class KakaoService {
                     .nickname(userInfo.getKakaoAccount().getProfile().getNickName())
                     .profileImg(userInfo.getKakaoAccount().getProfile().getProfileImageUrl())
                     .email(userInfo.getKakaoAccount().getEmail())
-                    .level("새싹")
+                    .level("새싹 플로거")
                     .stampCount(0L)
                     .build(); // 회원가입 처리 로직 추가
 

--- a/src/main/java/footlogger/footlog/web/dto/response/UserResponseDto.java
+++ b/src/main/java/footlogger/footlog/web/dto/response/UserResponseDto.java
@@ -26,9 +26,6 @@ public class UserResponseDto {
         private String profileImg;
         private String level;
         private Long stampCount;
-//        private List<SaveCourseDto> saveCourseList;
-//        private List<CheckCourseDto> checkCourseList;
-
     }
 
     @Builder


### PR DESCRIPTION
## 연관 이슈

#8 

<br/>

## 개요

유저 스탬프 로직 구현

<br/>

## ✅ 작업 내용

- [x] 완주하기 클릭 시 스탬프 증가
<img width="775" alt="image" src="https://github.com/user-attachments/assets/ddf52ee4-f94e-4271-aed3-42d081f6f5ea">

완주하기 클릭할 때마다 스탬프 개수 증가합니다.

- [x] 스탬프 개수에 따른 레벨 처리 로직 구현
<img width="770" alt="image" src="https://github.com/user-attachments/assets/9f36a05a-d128-46f3-ac4e-dcf633191eea">

5까지는 새싹으로 처리됩니다.
<img width="775" alt="image" src="https://github.com/user-attachments/assets/449f3e0c-3bb8-44b9-93fb-2d32155b0ae3">

총 스탬프 개수가 6개부터 초보로 바뀌며 1로 세팅됩니다.
- [x] 회원 가입시 레벨 이름 변경
<img width="780" alt="image" src="https://github.com/user-attachments/assets/9d3d216c-3618-4b00-9dbd-aad7704a7977">

회원가입시 새싹 -> 새싹 플로거로 이름 변경했습니다.

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
